### PR TITLE
Fix bug on osx.

### DIFF
--- a/include/probability.hpp
+++ b/include/probability.hpp
@@ -23,6 +23,7 @@
 #include <limits>
 #include <cassert>
 #include <algorithm>
+#include <cmath>
 
 namespace probability {
 


### PR DESCRIPTION
Compiler cant find definition of 'std::log' and 'std::exp'. To fix it just add the 'cmath' standard header.
